### PR TITLE
Don't instantiate NSException if the OS is Linux

### DIFF
--- a/Sources/Require.swift
+++ b/Sources/Require.swift
@@ -23,7 +23,6 @@ public extension Optional {
                  line: UInt = #line) -> Wrapped {
         guard let unwrapped = self else {
             var message = "Required value was nil in \(file), at line \(line)"
-            
             if let hint = hintExpression() {
                 message.append(". Debugging hint: \(hint)")
             }

--- a/Sources/Require.swift
+++ b/Sources/Require.swift
@@ -23,21 +23,21 @@ public extension Optional {
                  line: UInt = #line) -> Wrapped {
         guard let unwrapped = self else {
             var message = "Required value was nil in \(file), at line \(line)"
-
+            
             if let hint = hintExpression() {
                 message.append(". Debugging hint: \(hint)")
             }
-
-            let exception = NSException(
-                name: .invalidArgumentException,
-                reason: message,
-                userInfo: nil
-            )
-
+            #if !os(Linux)
+                let exception = NSException(
+                    name: .invalidArgumentException,
+                    reason: message,
+                    userInfo: nil
+                )
+            #endif
             exception.raise()
             preconditionFailure(message)
         }
-
+        
         return unwrapped
     }
 }

--- a/Sources/Require.swift
+++ b/Sources/Require.swift
@@ -33,8 +33,8 @@ public extension Optional {
                     reason: message,
                     userInfo: nil
                 )
+                exception.raise()
             #endif
-            exception.raise()
             preconditionFailure(message)
         }
         


### PR DESCRIPTION
To avoid compatibility errors with Linux, I encapsulated the creation and rise of `NSException` inside an `#if !os(Linux)`:
```swift
            #if !os(Linux)
                let exception = NSException(
                    name: .invalidArgumentException,
                    reason: message,
                    userInfo: nil
                )
                exception.raise()
            #endif
```

This check it's necessary because` NSException` is not part of the open source Swift version of Foundation as reported in Marathon [issue37](https://github.com/JohnSundell/Marathon/issues/37). 

I edited and tested the Linux implementation on a Vmware virtual machine with Ubuntu 16.04.2 and on a Raspberry Pi with Ubuntu 16.04.2.